### PR TITLE
Choose i2c-bus as parameter of begin()

### DIFF
--- a/Adafruit_MPR121/MPR121.py
+++ b/Adafruit_MPR121/MPR121.py
@@ -71,6 +71,7 @@ class MPR121(object):
         pass
 
     def begin(self, address=MPR121_I2CADDR_DEFAULT, i2c=None, **kwargs):
+        self.reset_count = 0
         """Initialize communication with the MPR121. 
 
         Can specify a custom I2C address for the device using the address 
@@ -139,7 +140,10 @@ class MPR121(object):
                 if ex.errno != 110:
                     raise ex
             # Else there was a timeout, so reset the device and retry.
-            self._reset()
+            self.reset_count += 1
+            if self.reset_count < MAX_I2C_RETRIES:
+                self._reset()
+            
             # Increase count and fail after maximum number of retries.
             count += 1
             if count >= MAX_I2C_RETRIES:

--- a/Adafruit_MPR121/MPR121.py
+++ b/Adafruit_MPR121/MPR121.py
@@ -70,7 +70,7 @@ class MPR121(object):
         # Nothing to do here since there is very little state in the class.
         pass
 
-    def begin(self, address=MPR121_I2CADDR_DEFAULT, i2c=None, **kwargs):
+    def begin(self, bus=None, address=MPR121_I2CADDR_DEFAULT, i2c=None, **kwargs):
         self.reset_count = 0
         """Initialize communication with the MPR121. 
 
@@ -89,8 +89,13 @@ class MPR121(object):
             # the MPR121 is very sensitive and requires repeated starts to read all
             # the registers.
             I2C.require_repeated_start()
-        # Save a reference to the I2C device instance for later communication.
-        self._device = i2c.get_i2c_device(address, **kwargs)
+        
+        # Check bus number and save a reference to the I2C device instance for later communication.
+        if bus != None :
+            self._device = i2c.get_i2c_device(address, int(bus), **kwargs)
+        else  :
+            self._device = i2c.get_i2c_device(address, **kwargs)
+
         return self._reset()
 
     def _reset(self):


### PR DESCRIPTION
I tried to use the MPR121 on another I2C bus then the default. 
- 7b12338: I added the capability to set the busnumber on begin(). 
- ae110c5:  Having more than one device on the bus also led to some endless calls of _reset(), so I did limit this to the maximum. 
