### PR TITLE
Two examples were added 

### DIFF
--- a/Adafruit_MPR121/MPR121.py
+++ b/Adafruit_MPR121/MPR121.py
@@ -103,7 +103,7 @@ class MPR121(object):
         if c != 0x24:
            return False
         # Set threshold for touch and release to default values.
-        self.set_thresholds(12, 6)
+        self.set_thresholds(40, 3)
         # Configure baseline filtering control registers.
         self._i2c_retry(self._device.write8, MPR121_MHDR, 0x01)
         self._i2c_retry(self._device.write8, MPR121_NHDR, 0x01)

--- a/Adafruit_MPR121/MPR121.py
+++ b/Adafruit_MPR121/MPR121.py
@@ -103,7 +103,7 @@ class MPR121(object):
         if c != 0x24:
            return False
         # Set threshold for touch and release to default values.
-        self.set_thresholds(40, 3)
+        self.set_thresholds(12, 6)
         # Configure baseline filtering control registers.
         self._i2c_retry(self._device.write8, MPR121_MHDR, 0x01)
         self._i2c_retry(self._device.write8, MPR121_NHDR, 0x01)

--- a/examples/midi_touch.py
+++ b/examples/midi_touch.py
@@ -95,7 +95,7 @@ def midiExample():
     #Setup the HAT
     cap=setup_capacitive_hat();
 
-    #Apply a shift (one octave) to the tones
+    #shift example to the tones (this line have no effect)
     octave=0
     notes_offset=[x+12*octave for x in notes]
 
@@ -117,9 +117,9 @@ def midiExample():
         		# First check if transitioned from not touched to touched.
         		if current_touched & pin_bit and not last_touched & pin_bit:
             			print '{0} touched!'.format(i)
-				#Here we will trigger the midi tones
+				#Here we will trigger the MIDI tones
 				if i == 11:
-					print "Changin instrument"
+					print "Changing instrument"
 					current_instrument+=1
 					current_instrument=current_instrument%len(instrument_array)
 					midi_out.set_instrument(instrument_array[current_instrument])
@@ -155,7 +155,7 @@ def midiExample():
                                                 octave=0
 
 					#We need shut down all the notes before change
-					#to avoid ""hang" notes
+					#to avoid "hang" notes
 					for i in notes_offset:
 						midi_out.note_off(i,127)
 

--- a/examples/midi_touch.py
+++ b/examples/midi_touch.py
@@ -1,0 +1,176 @@
+'''
+    Federico Ramos 13/August/2013
+
+    Before running, install timidity (sudo apt-get install timidity) and run:
+
+    timidity -iA &
+
+    midi base example by: Jeff Kinne
+    capacitive hat base code by: Tony DiCola
+
+    interesting links:
+	https://ccrma.stanford.edu/~craig/articles/linuxmidi/alsa-1.0/alsarawmidiout.c
+	http://zacvineyard.com/blog/2013/11/building-a-christmas-music-light-show-with-a-raspberry-pi
+	https://en.wikipedia.org/wiki/Guitar_tunings
+	http://www.electronics.dit.ie/staff/tscarff/Music_technology/midi/midi_note_numbers_for_octaves.htm
+	http://www.skoogmusic.com/manual/manual1.1/Skoog-Window/navigation/MIDI-Tab/index
+'''
+
+import pygame
+import pygame.midi
+from time import sleep
+import time
+import Adafruit_MPR121.MPR121 as MPR121
+
+notes=[28,29,31,33,35,36,38,40,41,43,45,47,48,50]
+
+def setup_capacitive_hat():
+	# Create MPR121 instance.
+	cap = MPR121.MPR121()
+
+	# Initialize communication with MPR121 using default I2C bus of device, and 
+	# default I2C address (0x5A).  On BeagleBone Black will default to I2C bus 0.
+	if not cap.begin():
+    		print 'Error initializing MPR121.  Check your wiring!'
+    		sys.exit(1)
+
+	# Alternatively, specify a custom I2C address such as 0x5B (ADDR tied to 3.3V),
+	# 0x5C (ADDR tied to SDA), or 0x5D (ADDR tied to SCL).
+	#cap.begin(address=0x5B)
+
+	# Also you can specify an optional I2C bus with the bus keyword parameter.
+	#cap.begin(bus=1)
+
+	#Stop the chip to set a new threshold value 0x00 -> ECR
+	cap._i2c_retry(cap._device.write8,0x5E,0x00)
+
+	#I found this threshold works well with medium fruits (like peaches)
+	#Change this for your needs
+	cap.set_thresholds(50, 10)
+
+	#I will check if the register are written correctly (debug purposes)
+	#tth=cap._i2c_retry(cap._device.readU8,0x41);
+	#rth=cap._i2c_retry(cap._device.readU8,0x42);
+	#print "Touch TH:" + str(tth) + "Release TH: " +str(rth)
+
+	#Start again the ic
+	cap._i2c_retry(cap._device.write8,0x5E,0x8F)
+
+	return cap
+
+def midiExample():
+    # Things to consider when using pygame.midi:
+    #
+    # 1) Initialize the midi module with a to pygame.midi.init().
+    # 2) Create a midi.Output instance for the desired output device port.
+    # 3) Select instruments with set_instrument() method calls.
+    # 4) Play notes with note_on() and note_off() method calls.
+    # 5) Call pygame.midi.Quit() when finished. Though the midi module tries
+    #    to ensure that midi is properly shut down, it is best to do it
+    #    explicitly. A try/finally statement is the safest way to do this.
+    #
+
+    #Not all instruments will work :(, I only tested this
+    GRAND_PIANO = 0
+    CHURCH_ORGAN = 19
+    GUITAR=25
+    DRUMB=115
+    SAX=65
+    VIOLA=42
+    TROMBONE=58
+    
+    instrument_array=[GRAND_PIANO,CHURCH_ORGAN,GUITAR,DRUMB,SAX,VIOLA,TROMBONE]
+    current_instrument=0
+    
+    #Init the pygame system
+    pygame.init()	
+
+    #Init the pygame midi system
+    pygame.midi.init()
+
+    
+    #Setup the output number 2, this is the timidity interface (check the beginning of the file)
+    midi_out = pygame.midi.Output(2, 0)
+
+    #Setup the HAT
+    cap=setup_capacitive_hat();
+
+    #Apply a shift (one octave) to the tones
+    octave=0
+    notes_offset=[x+12*octave for x in notes]
+
+    #Here goes the body of the program (loop)
+    try:
+        midi_out.set_instrument(instrument_array[current_instrument])
+
+	# Main loop to print a message every time a pin is touched.
+	print 'Press Ctrl-C to quit.'
+	last_touched = cap.touched()	
+
+	while True:
+    		current_touched = cap.touched()
+    		# Check each pin's last and current state to see if it was pressed or released.
+    		for i in range(12):
+        		# Each pin is represented by a bit in the touched value.  A value of 1
+        		# means the pin is being touched, and 0 means it is not being touched.
+        		pin_bit = 1 << i
+        		# First check if transitioned from not touched to touched.
+        		if current_touched & pin_bit and not last_touched & pin_bit:
+            			print '{0} touched!'.format(i)
+				#Here we will trigger the midi tones
+				if i == 11:
+					print "Changin instrument"
+					current_instrument+=1
+					current_instrument=current_instrument%len(instrument_array)
+					midi_out.set_instrument(instrument_array[current_instrument])
+				elif i== 10:
+					#Increment the tones
+					print "Octave increased, actual: "+str(octave)
+					octave+=1
+					if octave>8:
+						octave=8
+
+					#We need shut down all the notes before change
+                                        #to avoid "hang" notes
+					for i in notes_offset:
+                                                midi_out.note_off(i,127)
+
+					notes_offset=[x+12*octave for x in notes]
+				elif i==9:
+					#Do nothing, se need reserve this case for the 
+					#Decrement event
+					print ""
+				else:				
+					midi_out.note_on(notes_offset[i],127)
+				
+        		# Next check if transitioned from touched to not touched.
+        		if not current_touched & pin_bit and last_touched & pin_bit:
+            			print '{0} released!'.format(i)
+
+				if i== 9:
+                                        #Decrement the tones
+                                        print "Octave decremented, actual: "+str(octave)
+                                        octave-=1
+                                        if octave<0:
+                                                octave=0
+
+					#We need shut down all the notes before change
+					#to avoid ""hang" notes
+					for i in notes_offset:
+						midi_out.note_off(i,127)
+
+                                        notes_offset=[x+12*octave for x in notes]
+				else:
+				#Here we will stop the midi tones
+					midi_out.note_off(notes_offset[i],127)
+    			# Update last state and wait a short period before repeating.
+    		last_touched = current_touched
+    		time.sleep(0.1)
+
+	
+
+    finally:
+        del midi_out
+        pygame.midi.quit()
+
+midiExample()

--- a/examples/simpletest_new_threshold.py
+++ b/examples/simpletest_new_threshold.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Tony DiCola
+#
+# Mods by Federico Ramos 13/Agust/2015 :
+#
+# The mods are for change the threshold values without writing the base source code
+# (MPR121.py), I think the best way is add some new features to the MPR121.py code, 
+# but for the moment this Work for me.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import sys
+import time
+
+import Adafruit_MPR121.MPR121 as MPR121
+
+
+print 'Adafruit MPR121 Capacitive Touch Sensor Test'
+
+# Create MPR121 instance.
+cap = MPR121.MPR121()
+
+# Initialize communication with MPR121 using default I2C bus of device, and 
+# default I2C address (0x5A).  On BeagleBone Black will default to I2C bus 0.
+if not cap.begin():
+    print 'Error initializing MPR121.  Check your wiring!'
+    sys.exit(1)
+
+# Alternatively, specify a custom I2C address such as 0x5B (ADDR tied to 3.3V),
+# 0x5C (ADDR tied to SDA), or 0x5D (ADDR tied to SCL).
+#cap.begin(address=0x5B)
+
+# Also you can specify an optional I2C bus with the bus keyword parameter.
+#cap.begin(bus=1)
+
+#Stop the chip to set a new threshold value 0x00 -> ECR
+cap._i2c_retry(cap._device.write8,0x5E,0x00)
+
+#I found this threshold works well with medium fruits (like peaches)
+#Change this for your needs
+cap.set_thresholds(50, 10)
+
+#I will check if the register are written correctly (debug purposes)
+#tth=cap._i2c_retry(cap._device.readU8,0x41);
+#rth=cap._i2c_retry(cap._device.readU8,0x42);
+#print "Touch TH:" + str(tth) + "Release TH: " +str(rth)
+
+#Start again the ic
+cap._i2c_retry(cap._device.write8,0x5E,0x8F)
+
+# Main loop to print a message every time a pin is touched.
+print 'Press Ctrl-C to quit.'
+last_touched = cap.touched()
+while True:
+    current_touched = cap.touched()
+    # Check each pin's last and current state to see if it was pressed or released.
+    for i in range(12):
+        # Each pin is represented by a bit in the touched value.  A value of 1
+        # means the pin is being touched, and 0 means it is not being touched.
+        pin_bit = 1 << i
+        # First check if transitioned from not touched to touched.
+        if current_touched & pin_bit and not last_touched & pin_bit:
+            print '{0} touched!'.format(i)
+        # Next check if transitioned from touched to not touched.
+        if not current_touched & pin_bit and last_touched & pin_bit:
+            print '{0} released!'.format(i)
+    # Update last state and wait a short period before repeating.
+    last_touched = current_touched
+    time.sleep(0.1)
+
+    # Alternatively, if you only care about checking one or a few pins you can 
+    # call the is_touched method with a pin number to directly check that pin.
+    # This will be a little slower than the above code for checking a lot of pins.
+    #if cap.is_touched(0):
+    #    print 'Pin 0 is being touched!'
+    
+    # If you're curious or want to see debug info for each pin, uncomment the
+    # following lines:
+    #print '\t\t\t\t\t\t\t\t\t\t\t\t\t 0x{0:0X}'.format(cap.touched())
+    #filtered = [cap.filtered_data(i) for i in range(12)]
+    #print 'Filt:', '\t'.join(map(str, filtered))
+    #base = [cap.baseline_data(i) for i in range(12)]
+    #print 'Base:', '\t'.join(map(str, base))


### PR DESCRIPTION
Hi, I was playing with the library, I found that the default threshold values are not good for the fruits that I am trying to attach to the electrodes, so I created another example (simpletest_new_threshold.py), I changed the threshold values in a very Dirty way, but works for me, I don't know if modify the original MPR121.py value is fine, because in the Adafruit page description of HAT says:

"We're working on a detailed tutorial, meanwhile you can check out the tutorial for the non-HAT/breakout-version of this chip with the Raspberry Pi here"

I added another example midi_touch.py , a MIDI interface, the main difference with the included example (playtest.py)  is you can modify tones and instrument.

See a video here: (you can enable the english subtitles)
https://www.youtube.com/watch?v=VS9qk9P21ok 
